### PR TITLE
Change defaults to module attribute

### DIFF
--- a/lib/ping_plug.ex
+++ b/lib/ping_plug.ex
@@ -5,17 +5,14 @@ defmodule PingPlug do
 
   import Plug.Conn
 
-  @spec defaults() :: Keyword.t
-  def defaults do
-    [
-      message:      "pong",
-      content_type: "text/plain",
-    ]
-  end
+  @defaults [
+    message:      "pong",
+    content_type: "text/plain",
+  ]
 
   @spec init(Keyword.t) :: Keyword.t
   def init(options) do
-    defaults
+    @defaults
     |> Keyword.merge(options)
     |> sanitize_options()
   end


### PR DESCRIPTION
To improve performance when calling for default values.

Since Elixir will evaluate module's attributes at compile time, this PR moves default values evaluation from function to module's attributes.